### PR TITLE
test: Add logout scenarios for basic logout, redirect, and access con…

### DIFF
--- a/SauceDemo.Tests/Helpers/BrowserHelper.cs
+++ b/SauceDemo.Tests/Helpers/BrowserHelper.cs
@@ -1,0 +1,27 @@
+namespace SauceDemo.Tests.Helpers
+{
+    using OpenQA.Selenium;
+
+    public static class BrowserHelper
+    {
+        public static void NavigateTo(IWebDriver driver, string url)
+        {
+            driver.Navigate().GoToUrl(url);
+        }
+
+        public static void GoBack(IWebDriver driver)
+        {
+            driver.Navigate().Back();
+        }
+
+        public static void GoForward(IWebDriver driver)
+        {
+            driver.Navigate().Forward();
+        }
+
+        public static void RefreshPage(IWebDriver driver)
+        {
+            driver.Navigate().Refresh();
+        }
+    }
+}

--- a/SauceDemo.Tests/Helpers/WaitHelper.cs
+++ b/SauceDemo.Tests/Helpers/WaitHelper.cs
@@ -1,0 +1,29 @@
+namespace SauceDemo.Tests.Helpers
+{
+    using System;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Support.UI;
+
+    public static class WaitHelper
+    {
+        public static IWebElement? WaitForElementToBeClickable(IWebDriver driver, Func<By, IWebElement?> findElementSafe, By locator, int timeoutSeconds = 5)
+        {
+            var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(timeoutSeconds));
+            return wait.Until(_ =>
+            {
+                var element = findElementSafe(locator);
+                return (element != null && element.Displayed && element.Enabled) ? element : null;
+            });
+        }
+
+        public static bool WaitForTextToBePresent(IWebDriver driver, Func<By, IWebElement?> findElementSafe, By locator, string expectedText, int timeoutSeconds = 5)
+        {
+            var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(timeoutSeconds));
+            return wait.Until(_ =>
+            {
+                var element = findElementSafe(locator);
+                return element?.Text.Contains(expectedText) ?? false;
+            });
+        }
+    }
+}

--- a/SauceDemo.Tests/Pages/LoginPageObject.cs
+++ b/SauceDemo.Tests/Pages/LoginPageObject.cs
@@ -1,13 +1,14 @@
 namespace SauceDemo.Tests.Pages
 {
     using OpenQA.Selenium;
+    using SauceDemo.Tests.Helpers;
 
     public class LoginPageObject : BasePageObject
     {
         public LoginPageObject(IWebDriver driver)
             : base(driver)
-            {
-            }
+        {
+        }
 
         private static By UsernameInputLocator => By.Id("user-name");
 
@@ -15,7 +16,7 @@ namespace SauceDemo.Tests.Pages
 
         private static By LoginButtonLocator => By.Id("login-button");
 
-        public void NavigateTo() => driver.Navigate().GoToUrl("https://www.saucedemo.com/");
+        public void NavigateTo() => BrowserHelper.NavigateTo(driver, "https://www.saucedemo.com/");
 
         public void Login(string username, string password)
         {

--- a/SauceDemo.Tests/Pages/MenuPageObject.cs
+++ b/SauceDemo.Tests/Pages/MenuPageObject.cs
@@ -1,6 +1,7 @@
 namespace SauceDemo.Tests.Pages
 {
     using OpenQA.Selenium;
+    using SauceDemo.Tests.Helpers;
 
     public class MenuPageObject : BasePageObject
     {
@@ -43,7 +44,7 @@ namespace SauceDemo.Tests.Pages
 
         public void ClickLogoutLink()
         {
-            FindElementSafe(LogoutLinkLocator)?.Click();
+            WaitHelper.WaitForElementToBeClickable(driver, FindElementSafe, LogoutLinkLocator)?.Click();
         }
 
         public void ClickResetLink()

--- a/SauceDemo.Tests/Pages/ProductsPageObject.cs
+++ b/SauceDemo.Tests/Pages/ProductsPageObject.cs
@@ -1,0 +1,15 @@
+namespace SauceDemo.Tests.Pages
+{
+    using OpenQA.Selenium;
+    using SauceDemo.Tests.Helpers;
+
+    public class ProductsPageObject : BasePageObject
+    {
+        public ProductsPageObject(IWebDriver driver)
+            : base(driver)
+        {
+        }
+
+        public void NavigateTo() => BrowserHelper.NavigateTo(driver, "https://www.saucedemo.com/inventory.html");
+    }
+}

--- a/SauceDemo.Tests/Tests/Features/Logout.feature
+++ b/SauceDemo.Tests/Tests/Features/Logout.feature
@@ -1,15 +1,33 @@
-@wip
 Feature: Logout
 
+    Scenario: Logout link redirects the user to login page
+        Given I open the login page
+        And I log in as "standard_user"
+        And I open the menu
+        When I click the logout link
+        Then the "login" page is displayed
+
+    Scenario: Logged out user cannot access protected pages via Back button
+        Given I open the login page
+        And I log in as "standard_user"
+        And I open the menu
+        When I click the logout link
+        And I click the back button
+        Then the "Epic sadface: You can only access '/inventory.html' when you are logged in." message is displayed
+
+    Scenario: Logged out user cannot access protected pages via direct URL
+        Given I open the login page
+        And I log in as "standard_user"
+        And I open the menu
+        When I click the logout link
+        And I open the products page
+        Then the "Epic sadface: You can only access '/inventory.html' when you are logged in." message is displayed
+    @wip
     Scenario: User who is actively using the app is not automatically logged out after 10 minutes
 
+    @wip
     #we are going to navigate to the cart. Maybe back button?
     Scenario: Idle user cannot cannot modify cart after automatic logout
-
-    Scenario: Logout link signs out the current user
-
-    #we are going to navigate to the cart. Maybe back button?
-    #I think I also need a test for accessing the app via typing into the url after logout
-    Scenario: Logged out user cannot access protected pages
-
+    
+    @wip
     Scenario: Cart contents are preserved after logout

--- a/SauceDemo.Tests/Tests/Features/Logout.feature.cs
+++ b/SauceDemo.Tests/Tests/Features/Logout.feature.cs
@@ -21,14 +21,12 @@ namespace SauceDemo.Tests.Tests.Features
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [NUnit.Framework.TestFixtureAttribute()]
     [NUnit.Framework.DescriptionAttribute("Logout")]
-    [NUnit.Framework.CategoryAttribute("wip")]
     public partial class LogoutFeature
     {
         
         private TechTalk.SpecFlow.ITestRunner testRunner;
         
-        private static string[] featureTags = new string[] {
-                "wip"};
+        private static string[] featureTags = ((string[])(null));
         
 #line 1 "Logout.feature"
 #line hidden
@@ -76,15 +74,133 @@ namespace SauceDemo.Tests.Tests.Features
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("User who is actively using the app is not automatically logged out after 10 minut" +
-            "es")]
-        public void UserWhoIsActivelyUsingTheAppIsNotAutomaticallyLoggedOutAfter10Minutes()
+        [NUnit.Framework.DescriptionAttribute("Logout link redirects the user to login page")]
+        public void LogoutLinkRedirectsTheUserToLoginPage()
         {
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Logout link redirects the user to login page", null, tagsOfScenario, argumentsOfScenario, featureTags);
+#line 3
+    this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 4
+        testRunner.Given("I open the login page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 5
+        testRunner.And("I log in as \"standard_user\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 6
+        testRunner.And("I open the menu", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 7
+        testRunner.When("I click the logout link", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 8
+        testRunner.Then("the \"login\" page is displayed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Logged out user cannot access protected pages via Back button")]
+        public void LoggedOutUserCannotAccessProtectedPagesViaBackButton()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Logged out user cannot access protected pages via Back button", null, tagsOfScenario, argumentsOfScenario, featureTags);
+#line 10
+    this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 11
+        testRunner.Given("I open the login page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 12
+        testRunner.And("I log in as \"standard_user\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 13
+        testRunner.And("I open the menu", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 14
+        testRunner.When("I click the logout link", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 15
+        testRunner.And("I click the back button", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 16
+        testRunner.Then("the \"Epic sadface: You can only access \'/inventory.html\' when you are logged in.\"" +
+                        " message is displayed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Logged out user cannot access protected pages via direct URL")]
+        public void LoggedOutUserCannotAccessProtectedPagesViaDirectURL()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Logged out user cannot access protected pages via direct URL", null, tagsOfScenario, argumentsOfScenario, featureTags);
+#line 18
+    this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 19
+        testRunner.Given("I open the login page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 20
+        testRunner.And("I log in as \"standard_user\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 21
+        testRunner.And("I open the menu", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 22
+        testRunner.When("I click the logout link", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 23
+        testRunner.And("I open the products page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 24
+        testRunner.Then("the \"Epic sadface: You can only access \'/inventory.html\' when you are logged in.\"" +
+                        " message is displayed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("User who is actively using the app is not automatically logged out after 10 minut" +
+            "es")]
+        [NUnit.Framework.CategoryAttribute("wip")]
+        public void UserWhoIsActivelyUsingTheAppIsNotAutomaticallyLoggedOutAfter10Minutes()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "wip"};
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("User who is actively using the app is not automatically logged out after 10 minut" +
                     "es", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 4
+#line 26
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
@@ -100,54 +216,14 @@ namespace SauceDemo.Tests.Tests.Features
         
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Idle user cannot cannot modify cart after automatic logout")]
+        [NUnit.Framework.CategoryAttribute("wip")]
         public void IdleUserCannotCannotModifyCartAfterAutomaticLogout()
         {
-            string[] tagsOfScenario = ((string[])(null));
+            string[] tagsOfScenario = new string[] {
+                    "wip"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Idle user cannot cannot modify cart after automatic logout", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 7
-    this.ScenarioInitialize(scenarioInfo);
-#line hidden
-            if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
-            {
-                testRunner.SkipScenario();
-            }
-            else
-            {
-                this.ScenarioStart();
-            }
-            this.ScenarioCleanup();
-        }
-        
-        [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Logout link signs out the current user")]
-        public void LogoutLinkSignsOutTheCurrentUser()
-        {
-            string[] tagsOfScenario = ((string[])(null));
-            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Logout link signs out the current user", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 10
-    this.ScenarioInitialize(scenarioInfo);
-#line hidden
-            if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
-            {
-                testRunner.SkipScenario();
-            }
-            else
-            {
-                this.ScenarioStart();
-            }
-            this.ScenarioCleanup();
-        }
-        
-        [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Logged out user cannot access protected pages")]
-        public void LoggedOutUserCannotAccessProtectedPages()
-        {
-            string[] tagsOfScenario = ((string[])(null));
-            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Logged out user cannot access protected pages", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 14
+#line 30
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
@@ -163,12 +239,14 @@ namespace SauceDemo.Tests.Tests.Features
         
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Cart contents are preserved after logout")]
+        [NUnit.Framework.CategoryAttribute("wip")]
         public void CartContentsArePreservedAfterLogout()
         {
-            string[] tagsOfScenario = ((string[])(null));
+            string[] tagsOfScenario = new string[] {
+                    "wip"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Cart contents are preserved after logout", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 16
+#line 33
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))

--- a/SauceDemo.Tests/Tests/Steps/BaseSteps.cs
+++ b/SauceDemo.Tests/Tests/Steps/BaseSteps.cs
@@ -6,7 +6,9 @@ namespace SauceDemo.Tests.Tests.Steps
 
     public abstract class BaseSteps
     {
-        private readonly IWebDriver driver;
+#pragma warning disable SA1401 // Fields should be private
+        protected readonly IWebDriver driver;
+#pragma warning restore SA1401 // Fields should be private
 
         protected BaseSteps(ScenarioContext scenarioContext)
         {
@@ -14,10 +16,10 @@ namespace SauceDemo.Tests.Tests.Steps
                       ?? throw new InvalidOperationException("WebDriver not found in ScenarioContext.");
         }
 
-        protected TPage Page<TPage>()
-            where TPage : BasePageObject
+        protected TPageObject PageObject<TPageObject>()
+            where TPageObject : BasePageObject
         {
-            return (TPage)Activator.CreateInstance(typeof(TPage), driver) !;
+            return (TPageObject)Activator.CreateInstance(typeof(TPageObject), driver) !;
         }
     }
 }

--- a/SauceDemo.Tests/Tests/Steps/ErrorFeedbackSteps.cs
+++ b/SauceDemo.Tests/Tests/Steps/ErrorFeedbackSteps.cs
@@ -12,7 +12,7 @@ namespace SauceDemo.Tests.Tests.Steps
         public ErrorFeedbackSteps(ScenarioContext scenarioContext)
             : base(scenarioContext)
         {
-            errorFeedback = Page<ErrorFeedbackPageObject>();
+            errorFeedback = PageObject<ErrorFeedbackPageObject>();
         }
 
         [When(@"I dismiss the error message")]

--- a/SauceDemo.Tests/Tests/Steps/LoginSteps.cs
+++ b/SauceDemo.Tests/Tests/Steps/LoginSteps.cs
@@ -12,7 +12,7 @@ namespace SauceDemo.Tests.Tests.Steps
         public LoginSteps(ScenarioContext scenarioContext)
             : base(scenarioContext)
         {
-            loginPage = Page<LoginPageObject>();
+            loginPage = PageObject<LoginPageObject>();
         }
 
         [Given(@"I am on the login page")]

--- a/SauceDemo.Tests/Tests/Steps/LogoutSteps.cs
+++ b/SauceDemo.Tests/Tests/Steps/LogoutSteps.cs
@@ -1,0 +1,36 @@
+namespace SauceDemo.Tests.Tests.Steps
+{
+    using SauceDemo.Tests.Helpers;
+    using SauceDemo.Tests.Pages;
+    using TechTalk.SpecFlow;
+
+    [Binding]
+    public class LogoutSteps : BaseSteps
+    {
+        private readonly MenuPageObject? menu;
+
+        public LogoutSteps(ScenarioContext scenarioContext)
+            : base(scenarioContext)
+        {
+            menu = PageObject<MenuPageObject>();
+        }
+
+        [Given(@"I open the menu")]
+        public void IOpenTheMenu()
+        {
+            menu?.OpenMenu();
+        }
+
+        [When(@"I click the logout link")]
+        public void IClickTheLogoutLink()
+        {
+            menu?.ClickLogoutLink();
+        }
+
+        [When(@"I click the back button")]
+        public void IClickTheBackButton()
+        {
+            BrowserHelper.GoBack(driver);
+        }
+    }
+}

--- a/SauceDemo.Tests/Tests/Steps/ProductsSteps.cs
+++ b/SauceDemo.Tests/Tests/Steps/ProductsSteps.cs
@@ -1,0 +1,20 @@
+namespace SauceDemo.Tests.Tests.Steps
+{
+    using SauceDemo.Tests.Pages;
+    using TechTalk.SpecFlow;
+
+    [Binding]
+    public class ProductsSteps : BaseSteps
+    {
+        private readonly ProductsPageObject? productsPage;
+
+        public ProductsSteps(ScenarioContext scenarioContext)
+            : base(scenarioContext)
+        {
+            productsPage = PageObject<ProductsPageObject>();
+        }
+
+        [When(@"I open the products page")]
+        public void IOpenTheProductsPage() => productsPage?.NavigateTo();
+    }
+}

--- a/SauceDemo.Tests/Tests/Steps/ShellSteps.cs
+++ b/SauceDemo.Tests/Tests/Steps/ShellSteps.cs
@@ -12,7 +12,7 @@ namespace SauceDemo.Tests.Tests.Steps
         public ShellSteps(ScenarioContext scenarioContext)
             : base(scenarioContext)
         {
-            shellPage = Page<ShellPageObject>();
+            shellPage = PageObject<ShellPageObject>();
         }
 
         [Then(@"the ""(.*)"" page is displayed")]


### PR DESCRIPTION
…trol

Adds supporting utilities:
- BrowserHelper: browser-level controls (url navigation, back button, etc)
- WaitHelper: wait for the menu to open before clicking the logout

Adds new POMs and Step Binding:
- LogoutSteps: step bindings for logout scenarios
- ProductsSteps: step binding for accessing products page
- ProductsPageObject: enables "open products page" step

Modifies existing code:
- LoginPageObject and MenuPageObject: now use BrowserHelper
- BaseSteps:
  - Renamed `Page` to `PageObject` for clarity (esp. when working with MenuPageObject)
  - Changed `driver` to protected so steps can use BrowserHelper
- ErrorFeedbackSteps, LoginSteps, ShellSteps: renamed member `Page` to `PageObject`

- Modifies Logout.feature to validate:
  - Logout link redirecting user to the login page
  - Logged out users cannot access protected pages via back button
  - Logged out users cannot access protected pages via direct URL