### PR TITLE
chore: Restructure PageObjects into Pages and Components

### DIFF
--- a/SauceDemo.Tests/Extensions/ElementExtensions.cs
+++ b/SauceDemo.Tests/Extensions/ElementExtensions.cs
@@ -45,5 +45,17 @@ namespace SauceDemo.Tests.Extensions
                 return null;
             }
         }
+
+        public static IWebElement? FindElementSafe(this IWebDriver driver, By locator)
+        {
+            try
+            {
+                return driver.FindElement(locator);
+            }
+            catch (NoSuchElementException)
+            {
+                return null;
+            }
+        }
     }
 }

--- a/SauceDemo.Tests/StepDefinitions/Steps/BaseSteps.cs
+++ b/SauceDemo.Tests/StepDefinitions/Steps/BaseSteps.cs
@@ -1,8 +1,8 @@
 namespace SauceDemo.Tests.StepDefinitions.Steps
 {
     using OpenQA.Selenium;
-    using SauceDemo.Tests.PageObjects;
     using SauceDemo.Tests.UI.Components;
+    using SauceDemo.Tests.UI.Pages;
     using TechTalk.SpecFlow;
 
     public abstract class BaseSteps
@@ -17,15 +17,15 @@ namespace SauceDemo.Tests.StepDefinitions.Steps
                       ?? throw new InvalidOperationException("WebDriver not found in ScenarioContext.");
         }
 
-        protected TPageObject PageObject<TPageObject>()
-            where TPageObject : BasePageObject
+        protected TPage Page<TPage>()
+            where TPage : BasePage
         {
-            var instance = Activator.CreateInstance(typeof(TPageObject), driver)
-                ?? throw new InvalidOperationException($"Could not create instance of {typeof(TPageObject).Name}");
-            return (TPageObject)instance;
+            var instance = Activator.CreateInstance(typeof(TPage), driver)
+                ?? throw new InvalidOperationException($"Could not create instance of {typeof(TPage).Name}");
+            return (TPage)instance;
         }
 
-        protected TComponent DriverComponent<TComponent>()
+        protected TComponent Component<TComponent>()
             where TComponent : BaseComponent
         {
             var instance = Activator.CreateInstance(typeof(TComponent), driver)

--- a/SauceDemo.Tests/StepDefinitions/Steps/CartIconSteps.cs
+++ b/SauceDemo.Tests/StepDefinitions/Steps/CartIconSteps.cs
@@ -11,7 +11,7 @@ namespace SauceDemo.Tests.StepDefinitions.Steps
         public CartIconSteps(ScenarioContext scenarioContext)
             : base(scenarioContext)
         {
-            cartIconComponent = DriverComponent<CartIconComponent>();
+            cartIconComponent = Component<CartIconComponent>();
         }
 
         [When(@"I click the cart icon")]

--- a/SauceDemo.Tests/StepDefinitions/Steps/ErrorFeedbackSteps.cs
+++ b/SauceDemo.Tests/StepDefinitions/Steps/ErrorFeedbackSteps.cs
@@ -1,18 +1,18 @@
 namespace SauceDemo.Tests.StepDefinitions.Steps
 {
-    using SauceDemo.Tests.PageObjects;
     using SauceDemo.Tests.StepDefinitions.TestHelpers;
+    using SauceDemo.Tests.UI.Components;
     using TechTalk.SpecFlow;
 
     [Binding]
     public class ErrorFeedbackSteps : BaseSteps
     {
-        private readonly ErrorFeedbackPageObject? errorFeedback;
+        private readonly ErrorFeedbackComponent? errorFeedback;
 
         public ErrorFeedbackSteps(ScenarioContext scenarioContext)
             : base(scenarioContext)
         {
-            errorFeedback = PageObject<ErrorFeedbackPageObject>();
+            errorFeedback = Component<ErrorFeedbackComponent>();
         }
 
         [When(@"I dismiss the error message")]

--- a/SauceDemo.Tests/StepDefinitions/Steps/InventorySteps.cs
+++ b/SauceDemo.Tests/StepDefinitions/Steps/InventorySteps.cs
@@ -1,6 +1,6 @@
 namespace SauceDemo.Tests.StepDefinitions.Steps
 {
-    using SauceDemo.Tests.PageObjects;
+    using SauceDemo.Tests.UI.Pages;
     using TechTalk.SpecFlow;
 
     [Binding]
@@ -11,7 +11,7 @@ namespace SauceDemo.Tests.StepDefinitions.Steps
         public InventorySteps(ScenarioContext scenarioContext)
             : base(scenarioContext)
         {
-            inventoryPage = PageObject<InventoryPage>();
+            inventoryPage = Page<InventoryPage>();
         }
 
         [When(@"I open the inventory page")]

--- a/SauceDemo.Tests/StepDefinitions/Steps/LoginSteps.cs
+++ b/SauceDemo.Tests/StepDefinitions/Steps/LoginSteps.cs
@@ -1,18 +1,18 @@
 namespace SauceDemo.Tests.StepDefinitions.Steps
 {
-    using SauceDemo.Tests.PageObjects;
     using SauceDemo.Tests.StepDefinitions.TestData;
+    using SauceDemo.Tests.UI.Pages;
     using TechTalk.SpecFlow;
 
     [Binding]
     public class LoginSteps : BaseSteps
     {
-        private readonly LoginPageObject? loginPage;
+        private readonly LoginPage? loginPage;
 
         public LoginSteps(ScenarioContext scenarioContext)
             : base(scenarioContext)
         {
-            loginPage = PageObject<LoginPageObject>();
+            loginPage = Page<LoginPage>();
         }
 
         [Given(@"I am on the login page")]

--- a/SauceDemo.Tests/StepDefinitions/Steps/MenuSteps.cs
+++ b/SauceDemo.Tests/StepDefinitions/Steps/MenuSteps.cs
@@ -1,17 +1,17 @@
 namespace SauceDemo.Tests.StepDefinitions.Steps
 {
-    using SauceDemo.Tests.PageObjects;
+    using SauceDemo.Tests.UI.Components;
     using TechTalk.SpecFlow;
 
     [Binding]
     public class MenuSteps : BaseSteps
     {
-        private readonly MenuPageObject? menu;
+        private readonly MenuComponent? menu;
 
         public MenuSteps(ScenarioContext scenarioContext)
             : base(scenarioContext)
         {
-            menu = PageObject<MenuPageObject>();
+            menu = Component<MenuComponent>();
         }
 
         [Given(@"I open the menu")]

--- a/SauceDemo.Tests/StepDefinitions/Steps/ShellSteps.cs
+++ b/SauceDemo.Tests/StepDefinitions/Steps/ShellSteps.cs
@@ -1,18 +1,18 @@
 namespace SauceDemo.Tests.StepDefinitions.Steps
 {
-    using SauceDemo.Tests.PageObjects;
     using SauceDemo.Tests.StepDefinitions.TestData;
+    using SauceDemo.Tests.UI.Pages;
     using TechTalk.SpecFlow;
 
     [Binding]
     public class ShellSteps : BaseSteps
     {
-        private readonly ShellPageObject? shellPage;
+        private readonly ShellPage? shellPage;
 
         public ShellSteps(ScenarioContext scenarioContext)
             : base(scenarioContext)
         {
-            shellPage = PageObject<ShellPageObject>();
+            shellPage = Page<ShellPage>();
         }
 
         [Then(@"the ""(.*)"" page is displayed")]

--- a/SauceDemo.Tests/UI/Components/ErrorFeedbackComponent.cs
+++ b/SauceDemo.Tests/UI/Components/ErrorFeedbackComponent.cs
@@ -1,10 +1,11 @@
-namespace SauceDemo.Tests.PageObjects
+namespace SauceDemo.Tests.UI.Components
 {
     using OpenQA.Selenium;
+    using SauceDemo.Tests.Extensions;
 
-    public class ErrorFeedbackPageObject : BasePageObject
+    public class ErrorFeedbackComponent : BaseComponent
     {
-        public ErrorFeedbackPageObject(IWebDriver driver)
+        public ErrorFeedbackComponent(IWebDriver driver)
             : base(driver)
         {
         }
@@ -13,11 +14,9 @@ namespace SauceDemo.Tests.PageObjects
 
         public string? GetErrorMessageText()
         {
-            var element = FindElementSafe(ErrorMessageLocator);
+            var element = Driver.FindElementSafe(ErrorMessageLocator);
             return element?.Text;
         }
-
-        public bool ErrorMessageIsVisible() => ElementIsVisible(ErrorMessageLocator);
 
         public bool UsernameErrorIconIsVisible() => ErrorIconIsVisible(By.CssSelector("#user-name ~ svg.error_icon"));
 
@@ -29,18 +28,18 @@ namespace SauceDemo.Tests.PageObjects
 
         public void DismissErrorFeedback()
         {
-            FindElementSafe(By.ClassName("error-button"))?.Click();
+            Driver.FindRequiredElement(By.ClassName("error-button"))?.Click();
         }
 
         private bool ErrorIconIsVisible(By locator)
         {
-            var element = FindElementSafe(locator);
+            var element = Driver.FindElementSafe(locator);
             return element != null && element.Displayed;
         }
 
         private string? GetInputBottomBorderColor(string id)
         {
-            var element = FindElementSafe(By.Id(id));
+            var element = Driver.FindRequiredElement(By.Id(id));
             return element?.GetCssValue("border-bottom-color");
         }
     }

--- a/SauceDemo.Tests/UI/Components/MenuComponent.cs
+++ b/SauceDemo.Tests/UI/Components/MenuComponent.cs
@@ -1,11 +1,12 @@
-namespace SauceDemo.Tests.PageObjects
+namespace SauceDemo.Tests.UI.Components
 {
     using OpenQA.Selenium;
+    using SauceDemo.Tests.Extensions;
     using SauceDemo.Tests.Helpers;
 
-    public class MenuPageObject : BasePageObject
+    public class MenuComponent : BaseComponent
     {
-        public MenuPageObject(IWebDriver driver)
+        public MenuComponent(IWebDriver driver)
             : base(driver)
         {
         }
@@ -24,32 +25,32 @@ namespace SauceDemo.Tests.PageObjects
 
         public void OpenMenu()
         {
-            FindElementSafe(OpenMenuButtonLocator)?.Click();
+            Driver.FindRequiredElement(OpenMenuButtonLocator)?.Click();
         }
 
         public void CloseMenu()
         {
-            FindElementSafe(CloseMenuButtonLocator)?.Click();
+            Driver.FindRequiredElement(CloseMenuButtonLocator)?.Click();
         }
 
         public void ClickInventoryLink()
         {
-            FindElementSafe(InventoryLinkLocator)?.Click();
+            Driver.FindRequiredElement(InventoryLinkLocator)?.Click();
         }
 
         public void ClickAboutLink()
         {
-            FindElementSafe(AboutLinkLocator)?.Click();
+            Driver.FindRequiredElement(AboutLinkLocator)?.Click();
         }
 
         public void ClickLogoutLink()
         {
-            WaitHelper.WaitForElementToBeClickable(driver, FindElementSafe, LogoutLinkLocator)?.Click();
+            WaitHelper.WaitForElementToBeClickable(Driver, Driver.FindRequiredElement, LogoutLinkLocator)?.Click();
         }
 
         public void ClickResetLink()
         {
-            FindElementSafe(ResetLinkLocator)?.Click();
+            Driver.FindRequiredElement(ResetLinkLocator)?.Click();
         }
     }
 }

--- a/SauceDemo.Tests/UI/Pages/BasePage.cs
+++ b/SauceDemo.Tests/UI/Pages/BasePage.cs
@@ -1,14 +1,14 @@
-namespace SauceDemo.Tests.PageObjects
+namespace SauceDemo.Tests.UI.Pages
 {
     using OpenQA.Selenium;
 
-    public abstract class BasePageObject
+    public abstract class BasePage
     {
 #pragma warning disable SA1401 // Fields should be private
         protected readonly IWebDriver driver;
 #pragma warning restore SA1401 // Fields should be private
 
-        public BasePageObject(IWebDriver driver)
+        public BasePage(IWebDriver driver)
         {
             this.driver = driver;
         }

--- a/SauceDemo.Tests/UI/Pages/InventoryPage.cs
+++ b/SauceDemo.Tests/UI/Pages/InventoryPage.cs
@@ -1,9 +1,9 @@
-namespace SauceDemo.Tests.PageObjects
+namespace SauceDemo.Tests.UI.Pages
 {
     using OpenQA.Selenium;
     using SauceDemo.Tests.Helpers;
 
-    public class InventoryPage : BasePageObject
+    public class InventoryPage : BasePage
     {
         public InventoryPage(IWebDriver driver)
             : base(driver)

--- a/SauceDemo.Tests/UI/Pages/LoginPage.cs
+++ b/SauceDemo.Tests/UI/Pages/LoginPage.cs
@@ -1,11 +1,11 @@
-namespace SauceDemo.Tests.PageObjects
+namespace SauceDemo.Tests.UI.Pages
 {
     using OpenQA.Selenium;
     using SauceDemo.Tests.Helpers;
 
-    public class LoginPageObject : BasePageObject
+    public class LoginPage : BasePage
     {
-        public LoginPageObject(IWebDriver driver)
+        public LoginPage(IWebDriver driver)
             : base(driver)
         {
         }

--- a/SauceDemo.Tests/UI/Pages/ShellPage.cs
+++ b/SauceDemo.Tests/UI/Pages/ShellPage.cs
@@ -1,10 +1,10 @@
-namespace SauceDemo.Tests.PageObjects
+namespace SauceDemo.Tests.UI.Pages
 {
     using OpenQA.Selenium;
 
-    public class ShellPageObject : BasePageObject
+    public class ShellPage : BasePage
     {
-        public ShellPageObject(IWebDriver driver)
+        public ShellPage(IWebDriver driver)
             : base(driver)
         {
         }


### PR DESCRIPTION
Moves and renames core UI abstractions to align with Page and Component structure. Updates inheritance and namespaces accordingly.

Base classes and helpers:
- Rename BasePageObject to BasePage
- Move BasePage to Pages folder
- Update namespace
- Rename PageObject to Page in BaseSteps
- Rename DriverComponent to Component in BaseSteps

Pages:
- Move InventoryPage to Pages folder
- Rename LoginPageObject to LoginPage and update namespace
- Rename ShellPageObject to ShellPage and move to Pages folder
- Update all relevant namespaces

Components:
- Rename ErrorFeedbackPageObject to ErrorFeedbackComponent
- Change ErrorFeedbackComponent to inherit from BaseComponent
- Replace FindElementSafe with extension methods
- Move ErrorFeedbackComponent to Components folder
- Update namespace

- Rename MenuPageObject to MenuComponent
- Change MenuComponent to inherit from BaseComponent
- Replace FindElementSafe with extension methods
- Move MenuComponent to Components folder
- Update namespace

Step Definitions:
- Update namespace in CartIconSteps, InventorySteps, LoginSteps, ShellSteps
- Update MenuSteps to use Component<T> instead of Page<T>
- Update ErrorFeedbackSteps to use Component<T> instead of Page<T>