### PR TITLE
test: add menu component scenarios and supporting utilities

### DIFF
--- a/SauceDemo.Tests/Data/PageData.cs
+++ b/SauceDemo.Tests/Data/PageData.cs
@@ -2,9 +2,9 @@ namespace SauceDemo.Tests.Data
 {
     using SauceDemo.Tests.Models;
 
-    public static class PageData
+    public class PageData
     {
-        public static readonly Dictionary<string, PageModel> Pages = new (StringComparer.OrdinalIgnoreCase)
+        private readonly Dictionary<string, PageModel> pages = new (StringComparer.OrdinalIgnoreCase)
         {
             ["login"] = new PageModel("/", null),
             ["inventory"] = new PageModel("/inventory", "Products"),
@@ -13,14 +13,15 @@ namespace SauceDemo.Tests.Data
             ["checkout overview"] = new PageModel("/checkout-step-two", "Checkout: Overview"),
             ["checkout complete"] = new PageModel("/checkout-complete", "Checkout: Complete!"),
             ["item detail"] = new PageModel("/inventory-item", null), // no title here
+            ["sauce labs"] = new PageModel("saucelabs.com", null),
         };
 
-        public static PageModel Get(string alias)
+        public PageModel Get(string alias)
         {
-            if (!Pages.TryGetValue(alias, out var page))
+            if (!pages.TryGetValue(alias, out var page))
             {
                 throw new ArgumentException(
-                    $"Unknown page alias '{alias}'. Available options: {string.Join(", ", Pages.Keys)}");
+                    $"Unknown page alias '{alias}'. Available options: {string.Join(", ", pages.Keys)}");
             }
 
             return page;

--- a/SauceDemo.Tests/Helpers/WaitHelper.cs
+++ b/SauceDemo.Tests/Helpers/WaitHelper.cs
@@ -3,25 +3,46 @@ namespace SauceDemo.Tests.Helpers
     using System;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Support.UI;
+    using SauceDemo.Tests.Extensions;
 
     public static class WaitHelper
     {
-        public static IWebElement? WaitForElementToBeClickable(IWebDriver driver, Func<By, IWebElement?> findElementSafe, By locator, int timeoutSeconds = 5)
+        public static IWebElement? WaitForElementToBeClickable(
+            IWebDriver driver,
+            By locator,
+            int timeoutSeconds = 5)
         {
             var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(timeoutSeconds));
             return wait.Until(_ =>
             {
-                var element = findElementSafe(locator);
+                var element = driver.FindElementSafe(locator);
                 return (element != null && element.Displayed && element.Enabled) ? element : null;
             });
         }
 
-        public static bool WaitForTextToBePresent(IWebDriver driver, Func<By, IWebElement?> findElementSafe, By locator, string expectedText, int timeoutSeconds = 5)
+        public static void WaitForElementToDisappear(
+            IWebDriver driver,
+            By locator,
+            int timeoutSeconds = 2)
+        {
+            var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(timeoutSeconds));
+            wait.Until(_ =>
+            {
+                var element = driver.FindElementSafe(locator);
+                return element == null || !element.Displayed;
+            });
+        }
+
+        public static bool WaitForTextToBePresent(
+            IWebDriver driver,
+            By locator,
+            string expectedText,
+            int timeoutSeconds = 5)
         {
             var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(timeoutSeconds));
             return wait.Until(_ =>
             {
-                var element = findElementSafe(locator);
+                var element = driver.FindElementSafe(locator);
                 return element?.Text.Contains(expectedText) ?? false;
             });
         }

--- a/SauceDemo.Tests/StepDefinitions/Features/MenuComponent.feature
+++ b/SauceDemo.Tests/StepDefinitions/Features/MenuComponent.feature
@@ -1,15 +1,31 @@
-@wip
 Feature: Menu Component
 
-# Reset App State behavior is tested in:
-# - Inventory.feature
-# - InventoryDetail.feature
-# - CheckoutYourCart.feature
-# - CheckoutOverview.feature
+    # Reset App State behavior is tested in:
+    # - Inventory.feature
+    # - InventoryDetail.feature
+    # - CheckoutYourCart.feature
+    # - CheckoutOverview.feature
 
     Scenario: Close button hides the menu
+        Given I open the login page
+        And I log in as "standard_user"
+        And I open the menu
+        When I close the menu
+        Then the menu is not displayed
+
     @page-navigation
     Scenario: All Items link navigates to Inventory page
+        Given I open the login page
+        And I log in as "standard_user"
+        And I click the cart icon
+        And I open the menu
+        When I click the all items link
+        Then the "inventory" page is displayed
+
     @page-navigation
     Scenario: About link navigates to the Sauce Labs website
-
+        Given I open the login page
+        And I log in as "standard_user"
+        And I open the menu
+        When I click the about link
+        Then the "sauce labs" page is displayed

--- a/SauceDemo.Tests/StepDefinitions/Features/MenuComponent.feature.cs
+++ b/SauceDemo.Tests/StepDefinitions/Features/MenuComponent.feature.cs
@@ -21,14 +21,12 @@ namespace SauceDemo.Tests.StepDefinitions.Features
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [NUnit.Framework.TestFixtureAttribute()]
     [NUnit.Framework.DescriptionAttribute("Menu Component")]
-    [NUnit.Framework.CategoryAttribute("wip")]
     public partial class MenuComponentFeature
     {
         
         private TechTalk.SpecFlow.ITestRunner testRunner;
         
-        private static string[] featureTags = new string[] {
-                "wip"};
+        private static string[] featureTags = ((string[])(null));
         
 #line 1 "MenuComponent.feature"
 #line hidden
@@ -82,7 +80,7 @@ namespace SauceDemo.Tests.StepDefinitions.Features
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Close button hides the menu", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 10
+#line 9
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
@@ -92,6 +90,21 @@ namespace SauceDemo.Tests.StepDefinitions.Features
             else
             {
                 this.ScenarioStart();
+#line 10
+        testRunner.Given("I open the login page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 11
+        testRunner.And("I log in as \"standard_user\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 12
+        testRunner.And("I open the menu", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 13
+        testRunner.When("I close the menu", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 14
+        testRunner.Then("the menu is not displayed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
             }
             this.ScenarioCleanup();
         }
@@ -105,7 +118,7 @@ namespace SauceDemo.Tests.StepDefinitions.Features
                     "page-navigation"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("All Items link navigates to Inventory page", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 12
+#line 17
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
@@ -115,6 +128,24 @@ namespace SauceDemo.Tests.StepDefinitions.Features
             else
             {
                 this.ScenarioStart();
+#line 18
+        testRunner.Given("I open the login page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 19
+        testRunner.And("I log in as \"standard_user\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 20
+        testRunner.And("I click the cart icon", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 21
+        testRunner.And("I open the menu", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 22
+        testRunner.When("I click the all items link", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 23
+        testRunner.Then("the \"inventory\" page is displayed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
             }
             this.ScenarioCleanup();
         }
@@ -128,7 +159,7 @@ namespace SauceDemo.Tests.StepDefinitions.Features
                     "page-navigation"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("About link navigates to the Sauce Labs website", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 14
+#line 26
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
@@ -138,6 +169,21 @@ namespace SauceDemo.Tests.StepDefinitions.Features
             else
             {
                 this.ScenarioStart();
+#line 27
+        testRunner.Given("I open the login page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 28
+        testRunner.And("I log in as \"standard_user\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 29
+        testRunner.And("I open the menu", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 30
+        testRunner.When("I click the about link", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 31
+        testRunner.Then("the \"sauce labs\" page is displayed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
             }
             this.ScenarioCleanup();
         }

--- a/SauceDemo.Tests/StepDefinitions/Steps/CartIconSteps.cs
+++ b/SauceDemo.Tests/StepDefinitions/Steps/CartIconSteps.cs
@@ -14,6 +14,7 @@ namespace SauceDemo.Tests.StepDefinitions.Steps
             cartIconComponent = Component<CartIconComponent>();
         }
 
+        [Given(@"I click the cart icon")]
         [When(@"I click the cart icon")]
         public void IClickTheCartIcon() => cartIconComponent.ClickCartIcon();
 

--- a/SauceDemo.Tests/StepDefinitions/Steps/MenuSteps.cs
+++ b/SauceDemo.Tests/StepDefinitions/Steps/MenuSteps.cs
@@ -26,5 +26,33 @@ namespace SauceDemo.Tests.StepDefinitions.Steps
         {
             menu?.ClickLogoutLink();
         }
+
+        [When(@"I click the all items link")]
+        public void IClickTheAllItemsLink()
+        {
+            menu?.ClickAllItemsLink();
+        }
+
+        [When(@"I click the about link")]
+        public void IClickTheAboutLink()
+        {
+            menu?.ClickAboutLink();
+        }
+
+        [When(@"I close the menu")]
+        public void ICloseTheMenu()
+        {
+            menu?.CloseMenu();
+        }
+
+        [Then(@"the menu is not displayed")]
+        public void TheMenuIsNotDisplayed()
+        {
+            var actual = menu?.MenuIsVisible();
+            Assert.That(
+                actual,
+                Is.False,
+                $"Expected: '{Is.False}', Actual: '{actual}'");
+        }
     }
 }

--- a/SauceDemo.Tests/StepDefinitions/Steps/ShellSteps.cs
+++ b/SauceDemo.Tests/StepDefinitions/Steps/ShellSteps.cs
@@ -18,15 +18,21 @@ namespace SauceDemo.Tests.StepDefinitions.Steps
         [Then(@"the ""(.*)"" page is displayed")]
         public void ThePageIsDisplayed(string pageAlias)
         {
-            var expected = PageData.Get(pageAlias);
+            var expected = new PageData().Get(pageAlias);
             var actualUrl = shellPage?.PageUrl;
             Assert.Multiple(() =>
             {
-                Assert.That(actualUrl, Does.Contain(expected.UrlFragment), $"Expected URL to contain '{expected.UrlFragment}'");
+                Assert.That(
+                    actualUrl,
+                    Does.Contain(expected.UrlFragment),
+                    $"Expected URL to contain:'{expected.UrlFragment}', Actual: '{actualUrl}'");
 
                 if (expected.Title != null)
                 {
-                    Assert.That(shellPage?.PageTitle, Is.EqualTo(expected.Title), $"Expected page title '{expected.Title}'");
+                    Assert.That(
+                        shellPage?.PageTitle,
+                        Is.EqualTo(expected.Title),
+                        $"Expected: '{expected.Title}', Actual: '{shellPage?.PageTitle}'");
                 }
             });
         }

--- a/SauceDemo.Tests/UI/Components/MenuComponent.cs
+++ b/SauceDemo.Tests/UI/Components/MenuComponent.cs
@@ -1,5 +1,6 @@
 namespace SauceDemo.Tests.UI.Components
 {
+    using System;
     using OpenQA.Selenium;
     using SauceDemo.Tests.Extensions;
     using SauceDemo.Tests.Helpers;
@@ -11,46 +12,42 @@ namespace SauceDemo.Tests.UI.Components
         {
         }
 
-        private static By OpenMenuButtonLocator => By.Id("react-burger-menu-btn");
-
-        private static By CloseMenuButtonLocator => By.Id("react-burger-cross-btn");
-
-        private static By InventoryLinkLocator => By.Id("inventory_sidebar_link");
-
-        private static By AboutLinkLocator => By.Id("about_sidebar_link");
-
-        private static By LogoutLinkLocator => By.Id("logout_sidebar_link");
-
-        private static By ResetLinkLocator => By.Id("reset_sidebar_link");
-
         public void OpenMenu()
         {
-            Driver.FindRequiredElement(OpenMenuButtonLocator)?.Click();
+            Driver.FindRequiredElement(By.Id("react-burger-menu-btn"))?.Click();
         }
 
         public void CloseMenu()
         {
-            Driver.FindRequiredElement(CloseMenuButtonLocator)?.Click();
+            WaitHelper.WaitForElementToBeClickable(Driver, By.Id("react-burger-cross-btn"))?.Click();
         }
 
-        public void ClickInventoryLink()
+        public void ClickAllItemsLink()
         {
-            Driver.FindRequiredElement(InventoryLinkLocator)?.Click();
+            WaitHelper.WaitForElementToBeClickable(Driver, By.Id("inventory_sidebar_link"))?.Click();
         }
 
         public void ClickAboutLink()
         {
-            Driver.FindRequiredElement(AboutLinkLocator)?.Click();
+            WaitHelper.WaitForElementToBeClickable(Driver, By.Id("about_sidebar_link"))?.Click();
         }
 
         public void ClickLogoutLink()
         {
-            WaitHelper.WaitForElementToBeClickable(Driver, Driver.FindElementSafe, LogoutLinkLocator)?.Click();
+            WaitHelper.WaitForElementToBeClickable(Driver, By.Id("logout_sidebar_link"))?.Click();
         }
 
         public void ClickResetLink()
         {
-            Driver.FindRequiredElement(ResetLinkLocator)?.Click();
+            WaitHelper.WaitForElementToBeClickable(Driver, By.Id("reset_sidebar_link"))?.Click();
+        }
+
+        public bool MenuIsVisible()
+        {
+            var locator = By.ClassName("bm-menu-wrap");
+            WaitHelper.WaitForElementToDisappear(Driver, locator);
+            var element = Driver.FindElementSafe(locator);
+            return element != null && element.Displayed;
         }
     }
 }


### PR DESCRIPTION
- Add new MenuComponent.feature scenarios: close menu, click All Items, click About
- Implement supporting step bindings in MenuSteps
- Refactor MenuComponent: centralize locators, add visibility check, use wait logic
- Add WaitHelper.WaitForElementToDisappear to support menu visibility assertions
- Add Given attribute in CartIconSteps
- Refactor PageData: make Pages private, convert to instance class, update expected pages
- Update ShellSteps for new PageData structure and improve assertion messages