### PR TITLE
test: Add item detail loading scenarios

### DIFF
--- a/SauceDemo.Tests/Helpers/CssSelectorHelper.cs
+++ b/SauceDemo.Tests/Helpers/CssSelectorHelper.cs
@@ -1,0 +1,9 @@
+namespace SauceDemo.Tests.Helpers
+{
+    public static class CssSelectorHelper
+    {
+        public static string DataTestExact(string value) => $"[data-test='{value}']";
+
+        public static string DataTestEndsWith(string value) => $"[data-test$='{value}']";
+    }
+}

--- a/SauceDemo.Tests/Scripts/build.ps1
+++ b/SauceDemo.Tests/Scripts/build.ps1
@@ -1,8 +1,12 @@
-dotnet clean SauceDemo.Tests/SauceDemo.Tests.csproj
+# Get the absolute path to the solution folder based on script location
+$scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$solutionDir = Resolve-Path "$scriptPath\.."
+
+dotnet clean $solutionDir/SauceDemo.Tests.sln
 if ($LASTEXITCODE -ne 0) { throw "dotnet clean failed." }
 
-dotnet restore SauceDemo.Tests/SauceDemo.Tests.csproj
+dotnet restore $solutionDir/SauceDemo.Tests.sln
 if ($LASTEXITCODE -ne 0) { throw "dotnet restore failed." }
 
-dotnet build SauceDemo.Tests/SauceDemo.Tests.csproj --configuration Release --no-restore
+dotnet build $solutionDir/SauceDemo.Tests.sln --configuration Release --no-restore
 if ($LASTEXITCODE -ne 0) { throw "dotnet build failed." }

--- a/SauceDemo.Tests/Scripts/test.ps1
+++ b/SauceDemo.Tests/Scripts/test.ps1
@@ -1,2 +1,6 @@
-dotnet test SauceDemo.Tests/SauceDemo.Tests.csproj --configuration Release --no-build --logger "trx;LogFileName=test-results.trx" --filter "TestCategory!=wip"
+# Get the absolute path to the solution folder based on script location
+$scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$solutionDir = Resolve-Path "$scriptPath\.."
+
+dotnet test $solutionDir/SauceDemo.Tests.sln --configuration Release --no-build --logger "trx;LogFileName=test-results.trx" --filter "TestCategory!=wip"
 if ($LASTEXITCODE -ne 0) { throw "dotnet test failed." }

--- a/SauceDemo.Tests/StepDefinitions/Features/ItemDetail.feature
+++ b/SauceDemo.Tests/StepDefinitions/Features/ItemDetail.feature
@@ -1,23 +1,38 @@
-@wip
 Feature: Item Detail
 
-    # Works from the image link and the name link. All properties from the selected item show up on the detail screen. Test multiple products.
     @page-navigation
     Scenario: Item Detail page displays correct item after selecting item name from Inventory
-    @page-navigation
-    Scenario: Item Detail page displays correct item after selecting image from Inventory    
-        When I click the "Sauce Labs Backpack" image
+        Given I open the login page
+        And I log in as "standard_user"
+        When I click the "Sauce Labs Fleece Jacket" link
+        Then the "item detail" page is displayed
+        And the item detail product area displays the "Sauce Labs Fleece Jacket"
 
+    @page-navigation
+    Scenario: Item Detail page displays correct item after selecting image from Inventory 
+        Given I open the login page
+        And I log in as "standard_user"
+        When I click the "Sauce Labs Onesie" image
+        Then the "item detail" page is displayed
+        And the item detail product area displays the "Sauce Labs Onesie"
+        
     @page-navigation
     Scenario: Item Detail page displays correct item after selecting item name from Cart
+        Given I open the login page
+        And I log in as "standard_user"
+        And I add "Sauce Labs Backpack" to the cart
+        And I click the cart icon
+        When I click the "Sauce Labs Backpack" link
+        Then the "item detail" page is displayed
+        And the item detail product area displays the "Sauce Labs Backpack"
 
-    @reset-app-state
+    @reset-app-state @wip
     Scenario: Reset App State link reverts item state and cart icon count to defaults
-    @cart-button-state
+    @cart-button-state @wip
     Scenario: Remove button displays Add to cart on Item Detail page after removing item from the cart
-    @cart-button-state
+    @cart-button-state @wip
     Scenario: Add to cart button displays Remove on Item Detail page after adding from inventory
-    @cart-button-state
+    @cart-button-state @wip
     Scenario: Add to cart button displays Add to cart on Item Detail page after removing from inventory
-    @cart-button-state
+    @cart-button-state @wip
     Scenario: Item Detail page loads Remove button if item is already in cart on page load

--- a/SauceDemo.Tests/StepDefinitions/Features/ItemDetail.feature.cs
+++ b/SauceDemo.Tests/StepDefinitions/Features/ItemDetail.feature.cs
@@ -21,14 +21,12 @@ namespace SauceDemo.Tests.StepDefinitions.Features
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [NUnit.Framework.TestFixtureAttribute()]
     [NUnit.Framework.DescriptionAttribute("Item Detail")]
-    [NUnit.Framework.CategoryAttribute("wip")]
     public partial class ItemDetailFeature
     {
         
         private TechTalk.SpecFlow.ITestRunner testRunner;
         
-        private static string[] featureTags = new string[] {
-                "wip"};
+        private static string[] featureTags = ((string[])(null));
         
 #line 1 "ItemDetail.feature"
 #line hidden
@@ -84,7 +82,7 @@ namespace SauceDemo.Tests.StepDefinitions.Features
                     "page-navigation"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Item Detail page displays correct item after selecting item name from Inventory", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 6
+#line 4
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
@@ -94,6 +92,21 @@ namespace SauceDemo.Tests.StepDefinitions.Features
             else
             {
                 this.ScenarioStart();
+#line 5
+        testRunner.Given("I open the login page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 6
+        testRunner.And("I log in as \"standard_user\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 7
+        testRunner.When("I click the \"Sauce Labs Fleece Jacket\" link", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 8
+        testRunner.Then("the \"item detail\" page is displayed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 9
+        testRunner.And("the item detail product area displays the \"Sauce Labs Fleece Jacket\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
             }
             this.ScenarioCleanup();
         }
@@ -107,7 +120,7 @@ namespace SauceDemo.Tests.StepDefinitions.Features
                     "page-navigation"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Item Detail page displays correct item after selecting image from Inventory", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 8
+#line 12
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
@@ -117,8 +130,20 @@ namespace SauceDemo.Tests.StepDefinitions.Features
             else
             {
                 this.ScenarioStart();
-#line 9
-        testRunner.When("I click the \"Sauce Labs Backpack\" image", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 13
+        testRunner.Given("I open the login page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 14
+        testRunner.And("I log in as \"standard_user\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 15
+        testRunner.When("I click the \"Sauce Labs Onesie\" image", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 16
+        testRunner.Then("the \"item detail\" page is displayed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 17
+        testRunner.And("the item detail product area displays the \"Sauce Labs Onesie\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             }
             this.ScenarioCleanup();
@@ -133,7 +158,7 @@ namespace SauceDemo.Tests.StepDefinitions.Features
                     "page-navigation"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Item Detail page displays correct item after selecting item name from Cart", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 12
+#line 20
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
@@ -143,6 +168,27 @@ namespace SauceDemo.Tests.StepDefinitions.Features
             else
             {
                 this.ScenarioStart();
+#line 21
+        testRunner.Given("I open the login page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 22
+        testRunner.And("I log in as \"standard_user\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 23
+        testRunner.And("I add \"Sauce Labs Backpack\" to the cart", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 24
+        testRunner.And("I click the cart icon", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 25
+        testRunner.When("I click the \"Sauce Labs Backpack\" link", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 26
+        testRunner.Then("the \"item detail\" page is displayed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 27
+        testRunner.And("the item detail product area displays the \"Sauce Labs Backpack\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
             }
             this.ScenarioCleanup();
         }
@@ -150,13 +196,15 @@ namespace SauceDemo.Tests.StepDefinitions.Features
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Reset App State link reverts item state and cart icon count to defaults")]
         [NUnit.Framework.CategoryAttribute("reset-app-state")]
+        [NUnit.Framework.CategoryAttribute("wip")]
         public void ResetAppStateLinkRevertsItemStateAndCartIconCountToDefaults()
         {
             string[] tagsOfScenario = new string[] {
-                    "reset-app-state"};
+                    "reset-app-state",
+                    "wip"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Reset App State link reverts item state and cart icon count to defaults", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 15
+#line 30
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
@@ -174,14 +222,16 @@ namespace SauceDemo.Tests.StepDefinitions.Features
         [NUnit.Framework.DescriptionAttribute("Remove button displays Add to cart on Item Detail page after removing item from t" +
             "he cart")]
         [NUnit.Framework.CategoryAttribute("cart-button-state")]
+        [NUnit.Framework.CategoryAttribute("wip")]
         public void RemoveButtonDisplaysAddToCartOnItemDetailPageAfterRemovingItemFromTheCart()
         {
             string[] tagsOfScenario = new string[] {
-                    "cart-button-state"};
+                    "cart-button-state",
+                    "wip"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Remove button displays Add to cart on Item Detail page after removing item from t" +
                     "he cart", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 17
+#line 32
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
@@ -199,14 +249,16 @@ namespace SauceDemo.Tests.StepDefinitions.Features
         [NUnit.Framework.DescriptionAttribute("Add to cart button displays Remove on Item Detail page after adding from inventor" +
             "y")]
         [NUnit.Framework.CategoryAttribute("cart-button-state")]
+        [NUnit.Framework.CategoryAttribute("wip")]
         public void AddToCartButtonDisplaysRemoveOnItemDetailPageAfterAddingFromInventory()
         {
             string[] tagsOfScenario = new string[] {
-                    "cart-button-state"};
+                    "cart-button-state",
+                    "wip"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Add to cart button displays Remove on Item Detail page after adding from inventor" +
                     "y", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 19
+#line 34
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
@@ -224,14 +276,16 @@ namespace SauceDemo.Tests.StepDefinitions.Features
         [NUnit.Framework.DescriptionAttribute("Add to cart button displays Add to cart on Item Detail page after removing from i" +
             "nventory")]
         [NUnit.Framework.CategoryAttribute("cart-button-state")]
+        [NUnit.Framework.CategoryAttribute("wip")]
         public void AddToCartButtonDisplaysAddToCartOnItemDetailPageAfterRemovingFromInventory()
         {
             string[] tagsOfScenario = new string[] {
-                    "cart-button-state"};
+                    "cart-button-state",
+                    "wip"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Add to cart button displays Add to cart on Item Detail page after removing from i" +
                     "nventory", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 21
+#line 36
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
@@ -248,13 +302,15 @@ namespace SauceDemo.Tests.StepDefinitions.Features
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Item Detail page loads Remove button if item is already in cart on page load")]
         [NUnit.Framework.CategoryAttribute("cart-button-state")]
+        [NUnit.Framework.CategoryAttribute("wip")]
         public void ItemDetailPageLoadsRemoveButtonIfItemIsAlreadyInCartOnPageLoad()
         {
             string[] tagsOfScenario = new string[] {
-                    "cart-button-state"};
+                    "cart-button-state",
+                    "wip"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Item Detail page loads Remove button if item is already in cart on page load", null, tagsOfScenario, argumentsOfScenario, featureTags);
-#line 23
+#line 38
     this.ScenarioInitialize(scenarioInfo);
 #line hidden
             if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))

--- a/SauceDemo.Tests/StepDefinitions/Steps/ProductSteps.cs
+++ b/SauceDemo.Tests/StepDefinitions/Steps/ProductSteps.cs
@@ -51,11 +51,29 @@ namespace SauceDemo.Tests.StepDefinitions.Steps
             AssertionHelper.AssertEqual(actual, expected, "Inventory product area");
         }
 
+        [Then(@"the item detail product area displays the ""(.*)""")]
+        public void TheItemDetailProductAreaDisplaysTheItem(string displayName)
+        {
+            var validProductName = productNameData.GetValidatedProductName(displayName);
+            var actual = productBrowsingComponent.GetProduct(validProductName);
+            var expected = productData.GetExpectedProductForInventory(validProductName);
+            AssertionHelper.AssertEqual(actual, expected, "Item Detail product area");
+        }
+
         [Given(@"I click the ""(.*)"" link")]
+        [When(@"I click the ""(.*)"" link")]
         public void IClickTheItemLink(string displayName)
         {
             var validProductName = productNameData.GetValidatedProductName(displayName);
             productComponent.ClickItemName(validProductName);
+        }
+
+        [Given(@"I click the ""(.*)"" image")]
+        [When(@"I click the ""(.*)"" image")]
+        public void IClickTheItemImage(string displayName)
+        {
+            var validProductName = productNameData.GetValidatedProductName(displayName);
+            productComponent.ClickItemImage(validProductName);
         }
     }
 }

--- a/SauceDemo.Tests/UI/Components/ProductComponent.cs
+++ b/SauceDemo.Tests/UI/Components/ProductComponent.cs
@@ -3,6 +3,7 @@ namespace SauceDemo.Tests.UI.Components
     using OpenQA.Selenium;
     using SauceDemo.Tests.Data;
     using SauceDemo.Tests.Extensions;
+    using SauceDemo.Tests.Helpers;
     using SauceDemo.Tests.Models;
 
     public class ProductComponent : ProductSharedComponent
@@ -16,6 +17,14 @@ namespace SauceDemo.Tests.UI.Components
         {
             var productContainer = GetProductContainerByAncestor(productName);
             productContainer.FindRequiredElement(By.CssSelector($"[data-test='{InventoryItemNameKey}']")).Click();
+        }
+
+        public void ClickItemImage(ProductNameModel productName)
+        {
+            var productContainer = GetProductContainerByAncestor(productName);
+            var imageDataTestValue = BuildImageDataTestValue(productName);
+            var imageSelector = CssSelectorHelper.DataTestEndsWith(imageDataTestValue);
+            productContainer.FindRequiredElement(By.CssSelector(imageSelector)).Click();
         }
 
         public ProductModel GetProduct(ProductNameModel productName)
@@ -41,13 +50,11 @@ namespace SauceDemo.Tests.UI.Components
             var quantity = productContainer.FindElementSafe(By.CssSelector("[data-test='item-quantity']"))?.Text;
 
             var validProductName = new ProductNameData().GetValidatedProductName(name);
-            var imageLocatorText = $"inventory-item-{validProductName.InternalName}-img";
-            var imageAlt = productContainer.
-                FindElementSafe(By.CssSelector($"[data-test='{imageLocatorText}']"))?
-                .GetAttribute("alt");
-            var imageSource = productContainer
-                .FindElementSafe(By.CssSelector($"[data-test='{imageLocatorText}']"))?
-                .GetAttribute("src")?
+            var imageDataTestValue = BuildImageDataTestValue(validProductName);
+            var imageSelector = CssSelectorHelper.DataTestEndsWith(imageDataTestValue);
+            var imageElement = productContainer.FindElementSafe(By.CssSelector(imageSelector));
+            var imageAlt = imageElement?.GetAttribute("alt");
+            var imageSource = imageElement?.GetAttribute("src")?
                 .Replace("https://www.saucedemo.com", string.Empty);
 
             return new ProductModel
@@ -59,6 +66,11 @@ namespace SauceDemo.Tests.UI.Components
                 ImageSource = imageSource,
                 Quantity = quantity,
             };
+        }
+
+        private string BuildImageDataTestValue(ProductNameModel productName)
+        {
+            return $"item-{productName.InternalName}-img";
         }
     }
 }


### PR DESCRIPTION
- Add three scenarios and supporting steps for validating ietm detail page loads correctly
- Add CssSelectorHelper to create commonly used data test selector strings
- Modify build and test scripts to handle running from project instead of repo